### PR TITLE
Initial Load testing for chat service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # load-testing
+
+This repository implements load and performance testing with k6 to perform on different components of remsfal-backend. 
+To perform a test on an endpoint read this [guide](docs/guide.md) as an example to handle a load testing on chat service. 
+
+
+

--- a/chat-requests.js
+++ b/chat-requests.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep} from 'k6';
 
-const BASE_URL     = __ENV.BASE_URL     || 'http://localhost:8080';
+const BASE_URL     = __ENV.BASE_URL     || 'http://localhost:8081';
 const PROJECT_ID   = __ENV.PROJECT_ID   || 'some-project-id';
 const TASK_ID      = __ENV.TASK_ID      || 'some-task-id';
 const SESSION_ID   = __ENV.SESSION_ID   || 'some-session-id';
@@ -47,10 +47,7 @@ export function uploadFileMessage() {
     const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chats/${SESSION_ID}/messages/upload`;
 
     // Generate 1 MB of dummy text (1,024 * 1024 = 1 MB).
-    // Each character is a byte when used in this manner.
     const oneMB = new Array(1024 * 1024).fill('A').join('');
-
-    // Wrap it in the file() helper so k6 does multipart boundaries, etc.
     let fileData = http.file(
         oneMB,        // 1 MB of "A"
         'large-file.txt', // file name
@@ -60,7 +57,6 @@ export function uploadFileMessage() {
     let params = {
         headers: {
             'Cookie': COOKIE_VALUE,
-            // Don't set Content-Type manually; k6 sets multipart boundaries automatically
         },
     };
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,128 @@
+# Guide to use k6 and a Quarkus Test to handle a load testing
+
+This guide provides instructions for running load tests using K6 in conjunction with a Quarkus test framework.
+I will use load testing on the chat service in remsfal-backend as an example. 
+## k6 implementation
+### Environment Variables
+set these environment variables in the chat-requests.js 
+
+- `const BASE_URL     = __ENV.BASE_URL`
+- `const PROJECT_ID   = __ENV.PROJECT_ID`
+- `const TASK_ID      = __ENV.TASK_ID`
+- `const SESSION_ID   = __ENV.SESSION_ID`
+- `const COOKIE_VALUE = __ENV.TEST_COOKIE`  
+
+These environment variables will be set by the Quarkus Test that will be explained later. 
+
+### Functions
+Implement functions to make the http requests, as en example like this:
+
+```javascript
+export function createChatSession() {
+    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chats`;
+    const params = {
+        headers: {
+            'Cookie': COOKIE_VALUE,
+            'Content-Type': 'application/json',
+        },
+    };
+    let res = http.post(url, null, params);
+    check(res, {
+        'createChatSession => 201': (r) => r.status === 201,
+    });
+    sleep(1);
+}
+```
+### Test Scenarios
+in another file like scenario-default.js define the load testing scenarios, like this:
+import sleep from k6, import the functions from chat-requests.js to be called and define scenarios. 
+These will be called and used in the Quarkus test. 
+
+```javascript
+import { sleep } from 'k6';
+import { createChatSession, sendTextMessage, uploadFileMessage } from './chat-requests.js';
+
+export let options = {
+    scenarios: {
+        ramping_test: {
+            executor: 'ramping-vus',
+            startVUs: 0,
+            stages: [
+                { duration: '10s', target: 1 },   // ramp up to 5 users
+                { duration: '10s', target: 2 },  // then up to 10
+                { duration: '10s', target: 0 },   // then back down
+            ],
+        },
+    },
+};
+
+export default function () {
+    createChatSession();
+    for (let i = 0; i < 10; i++) { // Corrected syntax
+        sendTextMessage();
+    }
+    uploadFileMessage();
+    sleep(2);
+}
+```
+## Quarkus Test Implementation
+### Set up environemt
+Set up the test data and the test environment. See the @BeforeEach function in
+[exmaple](docs/loadtesting.md). 
+
+### Build cookies to handle authentication for the service while load testing
+
+```java
+ Map<String, ?> cookies = buildCookies(
+                TestData.USER_ID,
+                TestData.USER_EMAIL,
+                Duration.ofMinutes(1000)
+        );
+```
+### set the path to your k6 scripts
+
+```java
+        String k6ScriptPath = "/home/example/IdeaProjects/load-testing/scenario-default.js";
+```
+
+### use ProcessBuilder to run k6 with the built cookies
+Use the proccess builder to make the k6 command to be run
+```java
+ProcessBuilder k6Pb = new ProcessBuilder(
+                "k6",
+                "run",
+                "--out", "json=./k6_results.json",
+                k6ScriptPath
+        );
+```
+in this example i just want the results as a json. 
+Then set the environment variables and run the process
+```java
+// Set the environment variables for k6.
+        Map<String, String> env = k6Pb.environment();
+        env.put("BASE_URL", "http://localhost:8081");
+        env.put("PROJECT_ID", TestData.PROJECT_ID_1);
+        env.put("TASK_ID", TASK_ID_1);
+        env.put("SESSION_ID", EXAMPLE_CHAT_SESSION_ID_1);
+        env.put("TEST_COOKIE", cookieString);
+
+        logger.info("Session Id" + EXAMPLE_CHAT_SESSION_ID_1);
+
+        Process k6Process = k6Pb.start();
+```
+### Stream the logs from k6 using BufferedReader
+```java
+try (BufferedReader k6OutReader = new BufferedReader(new InputStreamReader(k6Process.getInputStream()));
+             BufferedReader k6ErrReader = new BufferedReader(new InputStreamReader(k6Process.getErrorStream()))) {
+            String line;
+            while ((line = k6OutReader.readLine()) != null) {
+                System.out.println("[k6 OUT] " + line);
+            }
+            while ((line = k6ErrReader.readLine()) != null) {
+                System.err.println("[k6 ERR] " + line);
+            }
+        }
+        int k6ExitCode = k6Process.waitFor();
+        System.out.println("k6 finished with exitCode=" + k6ExitCode);
+```
+

--- a/docs/loadtesting.md
+++ b/docs/loadtesting.md
@@ -1,0 +1,139 @@
+# Load Testing Quarkus Test integrated with k6 Example
+
+```java
+import de.remsfal.core.model.project.TaskModel;
+import de.remsfal.service.TestData;
+import de.remsfal.service.boundary.authentication.SessionManager;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class loadtesting extends AbstractProjectResourceTest {
+
+    @Inject
+    Logger logger;
+
+    static final String TASK_ID_1 = "5b111b34-1073-4f48-a79d-f19b17e7d56b";
+    static final String TASK_ID_2 = "4b8cd355-ad07-437a-9e71-a4e2e3624957";
+    static final String EXAMPLE_CHAT_SESSION_ID_1 = "64ab9ef0-25ef-4a1c-81c9-5963f7c7d211";
+
+    @BeforeEach
+    protected void setup() throws Exception {
+        logger.info("Setting up test data");
+        logger.info("Setting up test users and projects. User " +  TestData.USER_ID +
+                " is the manager of all projects.");
+        super.setupTestUsers();
+        super.setupTestProjects();
+        logger.info("Setting up project memberships");
+        runInTransaction(() -> entityManager
+                .createNativeQuery("INSERT INTO PROJECT_MEMBERSHIP (PROJECT_ID, USER_ID, MEMBER_ROLE) VALUES (?,?,?)")
+                .setParameter(1, TestData.PROJECT_ID_1)
+                .setParameter(2, TestData.USER_ID_2)
+                .setParameter(3, "STAFF")
+                .executeUpdate());
+        logger.info("User " + TestData.USER_ID_2 + " is a caretaker in project " + TestData.PROJECT_ID_1);
+        runInTransaction(() -> entityManager
+                .createNativeQuery("INSERT INTO PROJECT_MEMBERSHIP (PROJECT_ID, USER_ID, MEMBER_ROLE) VALUES (?,?,?)")
+                .setParameter(1, TestData.PROJECT_ID_1)
+                .setParameter(2, TestData.USER_ID_3)
+                .setParameter(3, "LESSOR")
+                .executeUpdate());
+        logger.info("User " + TestData.USER_ID_3 + " is a lessor in project " + TestData.PROJECT_ID_1);
+        runInTransaction(() -> entityManager
+                .createNativeQuery("INSERT INTO PROJECT_MEMBERSHIP (PROJECT_ID, USER_ID, MEMBER_ROLE) VALUES (?,?,?)")
+                .setParameter(1, TestData.PROJECT_ID_1)
+                .setParameter(2, TestData.USER_ID_4)
+                .setParameter(3, "PROPRIETOR")
+                .executeUpdate());
+        logger.info("User " + TestData.USER_ID_4 + " is a proprietor in project " + TestData.PROJECT_ID_1);
+        runInTransaction(() -> entityManager
+                .createNativeQuery("INSERT INTO TASK (ID, TYPE, PROJECT_ID, TITLE, DESCRIPTION, STATUS, CREATED_BY)"
+                        +
+                        " VALUES (?,?,?,?,?,?,?)")
+                .setParameter(1, TASK_ID_1)
+                .setParameter(2, "TASK")
+                .setParameter(3, TestData.PROJECT_ID_1)
+                .setParameter(4, TestData.TASK_TITLE_1)
+                .setParameter(5, TestData.TASK_DESCRIPTION_1)
+                .setParameter(6, TaskModel.Status.OPEN.name())
+                .setParameter(7, TestData.USER_ID)
+                .executeUpdate());
+        runInTransaction(() -> entityManager
+                .createNativeQuery("INSERT INTO TASK (ID, TYPE, PROJECT_ID, TITLE, DESCRIPTION, STATUS, CREATED_BY)"
+                        +
+                        " VALUES (?,?,?,?,?,?,?)")
+                .setParameter(1, TASK_ID_2)
+                .setParameter(2, "DEFECT")
+                .setParameter(3, TestData.PROJECT_ID_1)
+                .setParameter(4, "DEFECT TITLE")
+                .setParameter(5, "DEFECT DESCRIPTION")
+                .setParameter(6, TaskModel.Status.OPEN.name())
+                .setParameter(7, TestData.USER_ID)
+                .executeUpdate());
+    }
+
+    @Test
+    public void testLoadWithK6AndPrometheusRemoteWrite() throws Exception {
+        // Build cookies from your existing logic.
+        Map<String, ?> cookies = buildCookies(
+                TestData.USER_ID,
+                TestData.USER_EMAIL,
+                Duration.ofMinutes(1000)
+        );
+        logger.info("Cookies: " + cookies);
+
+        String cookieString = SessionManager.ACCESS_COOKIE_NAME + "="
+                + cookies.get(SessionManager.ACCESS_COOKIE_NAME)
+                + "; " + SessionManager.REFRESH_COOKIE_NAME + "="
+                + cookies.get(SessionManager.REFRESH_COOKIE_NAME);
+        logger.info("Cookie String: " + cookieString);
+
+        String k6ScriptPath = "/home/example/IdeaProjects/load-testing/scenario-default.js";
+
+        ProcessBuilder k6Pb = new ProcessBuilder(
+                "k6",
+                "run",
+                "--out", "json=./k6_results.json",
+                k6ScriptPath
+        );
+
+        // Set the environment variables for k6.
+        Map<String, String> env = k6Pb.environment();
+        env.put("BASE_URL", "http://localhost:8081");
+        env.put("PROJECT_ID", TestData.PROJECT_ID_1);
+        env.put("TASK_ID", TASK_ID_1);
+        env.put("SESSION_ID", EXAMPLE_CHAT_SESSION_ID_1);
+        env.put("TEST_COOKIE", cookieString);
+
+        logger.info("Session Id" + EXAMPLE_CHAT_SESSION_ID_1);
+
+        Process k6Process = k6Pb.start();
+
+        try (BufferedReader k6OutReader = new BufferedReader(new InputStreamReader(k6Process.getInputStream()));
+             BufferedReader k6ErrReader = new BufferedReader(new InputStreamReader(k6Process.getErrorStream()))) {
+            String line;
+            while ((line = k6OutReader.readLine()) != null) {
+                System.out.println("[k6 OUT] " + line);
+            }
+            while ((line = k6ErrReader.readLine()) != null) {
+                System.err.println("[k6 ERR] " + line);
+            }
+        }
+        int k6ExitCode = k6Process.waitFor();
+        System.out.println("k6 finished with exitCode=" + k6ExitCode);
+        assertEquals(0, k6ExitCode, "k6 should exit with code 0 if successful");
+
+    }
+}
+```

--- a/requests.js
+++ b/requests.js
@@ -1,0 +1,73 @@
+import http from 'k6/http';
+import { check, sleep} from 'k6';
+
+const BASE_URL     = __ENV.BASE_URL     || 'http://localhost:8080';
+const PROJECT_ID   = __ENV.PROJECT_ID   || 'some-project-id';
+const TASK_ID      = __ENV.TASK_ID      || 'some-task-id';
+const SESSION_ID   = __ENV.SESSION_ID   || 'some-session-id';
+const COOKIE_VALUE = __ENV.TEST_COOKIE  || '';
+
+export function createChatSession() {
+    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chat`;
+    const params = {
+        headers: {
+            'Cookie': COOKIE_VALUE,
+            'Content-Type': 'application/json',
+        },
+    };
+    let res = http.post(url, null, params);
+    check(res, {
+        'createChatSession => 201': (r) => r.status === 201,
+    });
+    sleep(1);
+}
+
+export function sendTextMessage() {
+    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chat/${SESSION_ID}/messages`;
+    const payload = JSON.stringify({
+        chat_session_id: SESSION_ID,
+        sender_id: 'k6-sender-id',
+        contentType: 'TEXT',
+        content: 'Hello from k6 test!',
+    });
+    const params = {
+        headers: {
+            'Cookie': COOKIE_VALUE,
+            'Content-Type': 'application/json',
+        },
+    };
+    let res = http.post(url, payload, params);
+    check(res, {
+        'sendTextMessage => 201': (r) => r.status === 201,
+    });
+    sleep(1);
+}
+
+export function uploadFileMessage() {
+    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chat/${SESSION_ID}/messages/upload`;
+
+    // 1) Provide the file content, the file name, and the correct MIME type:
+    let fileData = http.file(
+        'Hello from k6.\n',     // file content
+        'hello.txt',            // file name
+        'text/plain'            // explicit MIME type
+    );
+
+    // 2) Let k6 handle the multipart boundary by passing `fileData` in the body.
+    // 3) Only supply necessary headers like Cookie:
+    let params = {
+        headers: {
+            'Cookie': COOKIE_VALUE
+            // DO NOT manually set 'Content-Type': k6 will do it for you
+        },
+    };
+
+    let formData = { file: fileData };
+    let res = http.post(url, formData, params);
+
+    check(res, {
+        'uploadFileMessage => 201': (r) => r.status === 201,
+    });
+
+    sleep(1);
+}

--- a/requests.js
+++ b/requests.js
@@ -8,7 +8,7 @@ const SESSION_ID   = __ENV.SESSION_ID   || 'some-session-id';
 const COOKIE_VALUE = __ENV.TEST_COOKIE  || '';
 
 export function createChatSession() {
-    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chat`;
+    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chats`;
     const params = {
         headers: {
             'Cookie': COOKIE_VALUE,
@@ -23,7 +23,7 @@ export function createChatSession() {
 }
 
 export function sendTextMessage() {
-    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chat/${SESSION_ID}/messages`;
+    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chats/${SESSION_ID}/messages`;
     const payload = JSON.stringify({
         chat_session_id: SESSION_ID,
         sender_id: 'k6-sender-id',
@@ -44,21 +44,23 @@ export function sendTextMessage() {
 }
 
 export function uploadFileMessage() {
-    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chat/${SESSION_ID}/messages/upload`;
+    const url = `${BASE_URL}/api/v1/projects/${PROJECT_ID}/tasks/${TASK_ID}/chats/${SESSION_ID}/messages/upload`;
 
-    // 1) Provide the file content, the file name, and the correct MIME type:
+    // Generate 1 MB of dummy text (1,024 * 1024 = 1 MB).
+    // Each character is a byte when used in this manner.
+    const oneMB = new Array(1024 * 1024).fill('A').join('');
+
+    // Wrap it in the file() helper so k6 does multipart boundaries, etc.
     let fileData = http.file(
-        'Hello from k6.\n',     // file content
-        'hello.txt',            // file name
-        'text/plain'            // explicit MIME type
+        oneMB,        // 1 MB of "A"
+        'large-file.txt', // file name
+        'text/plain'  // MIME type
     );
 
-    // 2) Let k6 handle the multipart boundary by passing `fileData` in the body.
-    // 3) Only supply necessary headers like Cookie:
     let params = {
         headers: {
-            'Cookie': COOKIE_VALUE
-            // DO NOT manually set 'Content-Type': k6 will do it for you
+            'Cookie': COOKIE_VALUE,
+            // Don't set Content-Type manually; k6 sets multipart boundaries automatically
         },
     };
 

--- a/scenario-default.js
+++ b/scenario-default.js
@@ -1,0 +1,23 @@
+import { sleep } from 'k6';
+import { createChatSession, sendTextMessage, uploadFileMessage } from './requests.js';
+
+export let options = {
+    scenarios: {
+        ramping_test: {
+            executor: 'ramping-vus',
+            startVUs: 0,
+            stages: [
+                { duration: '10s', target: 5 },   // ramp up to 5 users
+                { duration: '10s', target: 10 },  // then up to 10
+                { duration: '10s', target: 0 },   // then back down
+            ],
+        },
+    },
+};
+
+export default function () {
+    createChatSession();
+    sendTextMessage();
+    uploadFileMessage();
+    sleep(2);
+}

--- a/scenario-default.js
+++ b/scenario-default.js
@@ -7,8 +7,8 @@ export let options = {
             executor: 'ramping-vus',
             startVUs: 0,
             stages: [
-                { duration: '10s', target: 5 },   // ramp up to 5 users
-                { duration: '10s', target: 10 },  // then up to 10
+                { duration: '10s', target: 1 },   // ramp up to 5 users
+                { duration: '10s', target: 2 },  // then up to 10
                 { duration: '10s', target: 0 },   // then back down
             ],
         },
@@ -17,7 +17,9 @@ export let options = {
 
 export default function () {
     createChatSession();
-    sendTextMessage();
+    for (let i = 0; i < 10; i++) { // Corrected syntax
+        sendTextMessage();
+    }
     uploadFileMessage();
     sleep(2);
 }

--- a/scenario-default.js
+++ b/scenario-default.js
@@ -1,5 +1,5 @@
 import { sleep } from 'k6';
-import { createChatSession, sendTextMessage, uploadFileMessage } from './requests.js';
+import { createChatSession, sendTextMessage, uploadFileMessage } from './chat-requests.js';
 
 export let options = {
     scenarios: {


### PR DESCRIPTION
# Initial Load testing for chat service

This PR will implement an initial implementation for load testing with k6 and how to implement it with a Quarkus test for handling cookies etc. 

Enhances #1 

## Scenarios 
- creating a chat session, sending 10 text messages and uploading a 1MB file to test the Apache Cassandra and Minio 
   - Ramp up the number of virtual users (VUs)
   - Maintain peak load
   - Gradually reduce the load
 
## Guide

A simple guide to integrate k6 scripts with a quarkus test to handle the session and cookies. See `docs/guide.md`
